### PR TITLE
fix perf.js attr_or_default()

### DIFF
--- a/perf.js
+++ b/perf.js
@@ -204,7 +204,7 @@ function log_ticks(axis) {
 }
 
 function attr_or_default(div, key, def) {
-    var res = div.attr(key);
+    var res = div.attr('data-' + key);
     return res == undefined ? def : res;
 }
 


### PR DESCRIPTION
 In html sample of  README.md, you set div parameter's material  "data-***". But when calling attr_or_default() in perf.js, it's missing string "data-". So I modified this bug.
